### PR TITLE
Pin setup-php action to v2.37.1

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Setup PHP
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@v2.37.1
       with:
         php-version: ${{ matrix.php }}
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Setup PHP
-      uses: shivammathur/setup-php@v2.37.1
+      uses: shivammathur/setup-php@2.37.1
       with:
         php-version: ${{ matrix.php }}
 


### PR DESCRIPTION
## Summary
Updated the `shivammathur/setup-php` GitHub Action to use a specific version pin instead of the floating `v2` tag.

## Changes
- Pinned `shivammathur/setup-php` action from `v2` to `v2.37.1` in the PHP workflow

## Details
This change improves workflow reproducibility and stability by using an explicit version rather than relying on the floating `v2` tag, which could introduce unexpected changes in future runs. Version `v2.37.1` is locked in to ensure consistent PHP setup behavior across all workflow executions.

https://claude.ai/code/session_01NL2NeqWvbxTnNx29PWqQBt